### PR TITLE
[Feat] Add token route for retrieving token contract address

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import swaggerUi from 'swagger-ui-express';
 import { specs, swaggerUiOptions } from './config/swagger.config';
 import relayRoute from "./route/relay.route";
 import registerRoute from "./route/register.route";
+import tokenRoute from "./route/token.route";
 
 const app : Express = express();
 app.use(express.json());
@@ -23,5 +24,6 @@ app.use('/api/protected', jwtGuard);
 app.use('/api/protected/auth', authRoute);
 app.use('/api/relay', relayRoute);
 app.use('/api/protected/register', registerRoute);
+app.use('/api/token', tokenRoute);
 
 export default app;

--- a/src/config/ludex.config.ts
+++ b/src/config/ludex.config.ts
@@ -29,7 +29,7 @@ export function createLudexConfig(contracts: Contracts): ludex.configs.LudexConf
     };
 }
 
-export async function getContracts(): Promise<Contracts> {
+export function getContracts(): Contracts {
     const deploymentMap: Contracts = {};
     const network = contracts.find(c => c.network === "op_sepolia"); // or make dynamic later
 

--- a/src/controller/token.controller.ts
+++ b/src/controller/token.controller.ts
@@ -1,0 +1,5 @@
+import {findTokenAddress} from "../service/token.service";
+
+export function getTokenAddressControl() {
+    return findTokenAddress();
+}

--- a/src/route/token.route.ts
+++ b/src/route/token.route.ts
@@ -1,0 +1,44 @@
+import {Router} from "express";
+import {getTokenAddressControl} from "../controller/token.controller";
+
+const router: Router = Router();
+
+/**
+ * @swagger
+ * /api/token/get/address:
+ *   get:
+ *     summary: 토큰 컨트랙트 주소 조회
+ *     description: 현재 등록된 토큰 컨트랙트의 address를 반환합니다.
+ *     tags:
+ *       - Token
+ *     responses:
+ *       200:
+ *         description: 토큰 주소 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 tokenAddress:
+ *                   type: string
+ *                   example: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
+ *       404:
+ *         description: 토큰 주소가 설정되지 않은 경우
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "Token address not found"
+ */
+router.get('/get/address', (req, res) => {
+    const address = getTokenAddressControl();
+    if (!address) {
+        res.status(404).json({message: "Token address not found"});
+    }
+    res.status(200).json({tokenAddress: address});
+});
+
+export default router;

--- a/src/service/item.service.ts
+++ b/src/service/item.service.ts
@@ -11,7 +11,7 @@ export async function registerItem(itemDto: RegisterItemDto) {
     const itemPrice: bigint = BigInt(itemDto.itemPrice);
     const shareTerms: number[] = itemDto.shareTerms;
 
-    const contracts: Contracts = await getContracts();
+    const contracts: Contracts = getContracts();
     const chainConfig = createChainConfig();
     const ludexConfig = createLudexConfig(contracts);
     const wallet = getWallet();

--- a/src/service/relay.service.ts
+++ b/src/service/relay.service.ts
@@ -2,7 +2,7 @@ import {Contracts, createLudexConfig, getContracts, getWallet} from "../config/l
 import * as ludex from "ludex";
 
 export async function createRelayer() {
-    const contracts: Contracts = await getContracts();
+    const contracts: Contracts = getContracts();
     const ludexConfig = createLudexConfig(contracts);
     const wallet = getWallet();
 

--- a/src/service/token.service.ts
+++ b/src/service/token.service.ts
@@ -1,0 +1,6 @@
+import {getContracts} from "../config/ludex.config";
+
+export function findTokenAddress() {
+    const contracts = getContracts();
+    return contracts["MockUSDC"].address;
+}


### PR DESCRIPTION
Introduced a new `/api/token/get/address` endpoint to fetch the token contract address. Refactored `getContracts` to be synchronous, removing unnecessary async calls. Added corresponding controller, service, and Swagger documentation for the token route.