### PR TITLE
fix: Update RPC URL handling and switch to public chain config

### DIFF
--- a/src/config/ludex.config.ts
+++ b/src/config/ludex.config.ts
@@ -9,7 +9,7 @@ export function createPrivateChainConfig (): ludex.configs.ChainConfig
     return {
         chainId: "0xAA37DC",
         chainName: "Optimism Sepolia",
-        rpcUrls: ["https://sepolia.optimism.io/"],
+        rpcUrls: [process.env.RPC_URL as string],
         nativeCurrency: {
             name: "ETH",
             symbol: "ETH",

--- a/src/service/config.service.ts
+++ b/src/service/config.service.ts
@@ -1,7 +1,11 @@
-import {createLudexConfig, createPrivateChainConfig, getContracts} from "../config/ludex.config";
+import {
+    createLudexConfig,
+    createPublicChainConfig,
+    getContracts
+} from "../config/ludex.config";
 
 export function getConfig() {
-    const chainConfig = createPrivateChainConfig();
+    const chainConfig = createPublicChainConfig();
     const contracts = getContracts();
     const ludexConfig = createLudexConfig(contracts);
     return {chainConfig, ludexConfig};


### PR DESCRIPTION
Replaced hardcoded RPC URL with environment variable for better flexibility. Updated configuration logic to use `createPublicChainConfig` instead of `createPrivateChainConfig` for public chain compatibility. These changes improve adaptability and support for external configurations.