### PR TITLE
feat: Fix JSON serialization for BigInt in relay route response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10786,6 +10786,7 @@
     "packages/LudexWeb3Integration": {
       "name": "ludex",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "ethers": "^6.13.5",

--- a/src/route/relay.route.ts
+++ b/src/route/relay.route.ts
@@ -8,7 +8,11 @@ router.post('/', async (req: Request, res: Response) => {
         console.log("0");
         const args = await relayControl(req);
         console.log("4");
-        res.status(200).json({ args });
+        const replacer = (_key: string, value: any) => {
+            return typeof value === 'bigint' ? value.toString() : value;
+        };
+
+        res.status(200).json(JSON.parse(JSON.stringify({ args }, replacer)));
     } catch (error) {
         if (error instanceof Error) {
             console.error("Error:", error.message);


### PR DESCRIPTION
Updated the `relay.route.ts` to properly handle serialization of `BigInt` values in JSON responses using a custom replacer function. Also includes minor metadata updates in `package-lock.json`.