### PR TITLE
feat: Refactor JSON serialization to use `stringifyBigInts`

### DIFF
--- a/src/route/relay.route.ts
+++ b/src/route/relay.route.ts
@@ -1,5 +1,6 @@
 import {Router, Request, Response} from "express";
 import {relayControl} from "../controller/relay.controller";
+import {stringifyBigInts} from "../service/relay.service";
 
 const router: Router = Router();
 
@@ -12,7 +13,7 @@ router.post('/', async (req: Request, res: Response) => {
             return typeof value === 'bigint' ? value.toString() : value;
         };
 
-        res.status(200).json(JSON.parse(JSON.stringify({ args }, replacer)));
+        res.status(200).json({ args: stringifyBigInts(args) });
     } catch (error) {
         if (error instanceof Error) {
             console.error("Error:", error.message);

--- a/src/service/relay.service.ts
+++ b/src/service/relay.service.ts
@@ -28,3 +28,17 @@ export async function handleRelayRequest(relayer: ludex.relay.RelayMaster, relay
         throw error;
     }
 }
+
+export function stringifyBigInts(obj: any): any {
+    if (typeof obj === 'bigint') {
+        return obj.toString();
+    } else if (Array.isArray(obj)) {
+        return obj.map(stringifyBigInts);
+    } else if (obj !== null && typeof obj === 'object') {
+        return Object.fromEntries(
+            Object.entries(obj).map(([k, v]) => [k, stringifyBigInts(v)])
+        );
+    } else {
+        return obj;
+    }
+}


### PR DESCRIPTION
Replaced manual `JSON.stringify` replacer logic with a reusable `stringifyBigInts` function for consistent bigint serialization. Simplifies route logic and improves maintainability by centralizing bigint handling in the service layer.