### PR TITLE
fix: Fix response serialization and add logging for debugging

### DIFF
--- a/src/route/relay.route.ts
+++ b/src/route/relay.route.ts
@@ -12,8 +12,9 @@ router.post('/', async (req: Request, res: Response) => {
         const replacer = (_key: string, value: any) => {
             return typeof value === 'bigint' ? value.toString() : value;
         };
-
-        res.status(200).json({ args: stringifyBigInts(args) });
+        console.log(`args1: ${JSON.stringify(args)}`);
+        console.log(`args2: ${stringifyBigInts(args)}`);
+        res.status(200).json({ args: JSON.stringify(args) });
     } catch (error) {
         if (error instanceof Error) {
             console.error("Error:", error.message);


### PR DESCRIPTION
Updated the response to correctly use `JSON.stringify` for args and added logging to compare the original and processed arguments. This helps in debugging issues with argument serialization.