### PR TITLE
refactor: Convert bigint to string for consistent Web3 ID handling

### DIFF
--- a/src/controller/item.controller.ts
+++ b/src/controller/item.controller.ts
@@ -5,7 +5,9 @@ import {storeWeb3Id} from "../grpc/storeId.client";
 export async function registerItemControl(itemDto: RegisterItemDto) {
     const gameId = itemDto.gameId;
     const { itemId, sharerIds } = await registerItem(itemDto);
-    const success = await storeWeb3Id(gameId, itemId, sharerIds);
+    const stringItemId = itemId.toString();
+    const stringSharerIds = sharerIds.map(id => id.toString());
+    const success = await storeWeb3Id(gameId, stringItemId, stringSharerIds);
     if (!success) {
         console.log("Failed to store web3Id");
     }

--- a/src/grpc/storeId.client.ts
+++ b/src/grpc/storeId.client.ts
@@ -10,17 +10,17 @@ const storeIdServiceClient = new StoreIdServiceClient(
 
 export const storeWeb3Id = (
     gameId: number,
-    itemId: bigint,
-    sharerIds: bigint[]
+    itemId: string,
+    sharerIds: string[]
 ): Promise<boolean> => {
     return new Promise((resolve, reject) => {
         const request = new storeIdRequest();
         request.setGameid(gameId);
-        request.setItemid(String(itemId));
+        request.setItemid(itemId);
         if (Array.isArray(sharerIds)) {
-            request.setShareridsList(sharerIds.map(id => String(id)));
+            request.setShareridsList(sharerIds);
         } else {
-            request.setShareridsList([String(sharerIds)]);
+            request.setShareridsList([sharerIds]);
         }
 
         storeIdServiceClient.storeWeb3Id(request, (err, res: BoolResult) => {


### PR DESCRIPTION
Updated itemId and sharerIds to be passed as strings instead of bigints when storing Web3 IDs. This ensures compatibility with the `storeId.client` implementation and eliminates unnecessary conversions.