### PR TITLE
[Refactor] Remove unique constraint from crypto wallet address field

### DIFF
--- a/src/entity/crypto_wallet.entity.ts
+++ b/src/entity/crypto_wallet.entity.ts
@@ -8,7 +8,7 @@ export class CryptoWallet {
     @Column({ name: 'user_id' })
     userId: number;
 
-    @Column({ name: 'address', unique: true })
+    @Column({ name: 'address' })
     address: string;
 
     @Column({ name: 'registered_at' })


### PR DESCRIPTION
The unique constraint on the "address" field has been removed to allow multiple entries with the same address. This change supports scenarios where duplicate wallet addresses need to be stored.