### PR TITLE
[Feat] Add sellerProxyAddress and purchaseProxyAddress

### DIFF
--- a/src/config/ludex.config.ts
+++ b/src/config/ludex.config.ts
@@ -42,6 +42,8 @@ export function createLudexConfig(contracts: Contracts): ludex.configs.LudexConf
         paymentProcessorAddress: contracts.PaymentProcessor.address,
         ledgerAddress: contracts.Ledger.address,
         storeAddress: contracts.Store.address,
+        sellerProxyAddress: contracts.SellerProxy.address,
+        purchaseProxyAddress: contracts.PurchaseProxy.address,
         forwarderAddress: contracts.ERC2771Forwarder.address
     };
 }


### PR DESCRIPTION
Include sellerProxyAddress and purchaseProxyAddress in the configuration. This ensures the system integrates these proxies for improved transaction handling and flexibility.