### PR TITLE
fix: Adjust profit retrieval to return formatted string instead of bi…

### DIFF
--- a/src/controller/profit.controller.ts
+++ b/src/controller/profit.controller.ts
@@ -1,6 +1,6 @@
 import {finalizePendingProfit, findWholePendingProfit} from "../service/profit.service";
 
-export async function getWholeProfitControl(): Promise<bigint> {
+export async function getWholeProfitControl(): Promise<string> {
     return await findWholePendingProfit();
 }
 

--- a/src/route/profit.route.ts
+++ b/src/route/profit.route.ts
@@ -30,7 +30,7 @@ const router: Router = Router();
  */
 router.get('/get/whole-pending', async (req, res) => {
     try {
-        const result = (await getWholeProfitControl()).toString();
+        const result = (await getWholeProfitControl());
         res.status(200).json({wholePendingProfit: result});
     } catch (error) {
         if (error instanceof Error) {

--- a/src/service/profit.service.ts
+++ b/src/service/profit.service.ts
@@ -3,7 +3,7 @@ import {Contracts, createLudexConfig, getContracts, getWallet, privateChainConfi
 import {findTokenAddress} from "./token.service";
 import {clearDelegatedItems, getDelegatedItems} from "../repository/redis.repository";
 
-export async function findWholePendingProfit(): Promise<bigint> {
+export async function findWholePendingProfit(): Promise<string> {
     const contracts: Contracts = getContracts();
     const chainConfig = privateChainConfig;
     const ludexConfig = createLudexConfig(contracts);
@@ -18,7 +18,12 @@ export async function findWholePendingProfit(): Promise<bigint> {
             .createServiceFacade(chainConfig, ludexConfig, wallet)
             .serviceAccessProfitEscrow();
 
-    return await profitEscrow.getWholePendingProfit(tokenAddress);
+    const profit: bigint = await profitEscrow.getWholePendingProfit(tokenAddress);
+    const raw = profit.toString();
+    const padded = raw.padStart(7, "0");
+    const integerPart = padded.slice(0, -6);
+    const decimalPart = padded.slice(-6).replace(/0+$/, "");
+    return decimalPart ? `${integerPart}.${decimalPart}` : integerPart;
 }
 
 export async function finalizePendingProfit() {


### PR DESCRIPTION
…gint

Updated `findWholePendingProfit` and related methods to return a formatted string with a padded and decimal representation. Adjusted the corresponding route implementation to align with the changes.